### PR TITLE
Fix links

### DIFF
--- a/how_to.asciidoc
+++ b/how_to.asciidoc
@@ -6,12 +6,11 @@ This document sets out the basics of how to prepare works for GITenberg.
 
 The tasks that need to be done for these books are documented on the following pages:
 
-* link:encoding[Encoding]
-* link:unicoding[Unicoding]
-* link:sectioning[Sectioning]
-* link:drop-caps[Drop Caps]
-* link:imaging[Adding images]
-* link:versioning[Versioning]
+* link:encoding.asciidoc[Encoding]
+* link:unicoding.asciidoc[Unicoding]
+* link:sectioning.asciidoc[Sectioning]
+* link:drop-caps.asciidoc[Drop Caps]
+* link:versioning.asciidoc[Versioning]
 
 == Help us select a starter set of PG texts!
 


### PR DESCRIPTION
I'm not sure if this change is actually necessary for other asciidoc processors, but it seems that Github's doesn't automatically resolve the `.asciidoc` extension.

Also removes the link to `imaging`, which doesn't exist yet.